### PR TITLE
Updated New Relic infra monitoring to 0.3.1

### DIFF
--- a/monitoring/newrelic/infra/terraform/00_main.tf
+++ b/monitoring/newrelic/infra/terraform/00_main.tf
@@ -20,7 +20,7 @@ provider "azurerm" {
 
 # Kubernetes infra monitoring
 module "nrotelk8s" {
-  source = "github.com/newrelic-experimental/monitoring-kubernetes-with-opentelemetry.git?ref=newrelic-monitoring-0.3.0/monitoring/terraform"
+  source = "github.com/newrelic-experimental/monitoring-kubernetes-with-opentelemetry.git?ref=newrelic-monitoring-0.3.1/monitoring/terraform"
 
   NEW_RELIC_ACCOUNT_ID = var.NEW_RELIC_ACCOUNT_ID
   NEW_RELIC_API_KEY    = var.NEW_RELIC_API_KEY


### PR DESCRIPTION
# Changes

- New Relic monitoring for infrastructure is updated to `newrelic-monitoring-0.3.1`.